### PR TITLE
Supporting POST requests and request headers

### DIFF
--- a/Include/AndroidExtensions/JavaWrappers.h
+++ b/Include/AndroidExtensions/JavaWrappers.h
@@ -221,6 +221,10 @@ namespace java::net
 
         bool GetDoOutput() const;
 
+        void SetDoOutput(bool n);
+
+        void SetRequestProperty(std::string key, std::string value);
+
         URL GetURL() const;
 
         int GetContentLength() const;

--- a/Include/AndroidExtensions/JavaWrappers.h
+++ b/Include/AndroidExtensions/JavaWrappers.h
@@ -218,7 +218,7 @@ namespace java::net
 
         int GetResponseCode() const;
 
-        void SetRequestMethod(std::string requestMethod);
+        void SetRequestMethod(const std::string& requestMethod);
     };
 
     class URL : public lang::Object

--- a/Include/AndroidExtensions/JavaWrappers.h
+++ b/Include/AndroidExtensions/JavaWrappers.h
@@ -219,6 +219,8 @@ namespace java::net
 
         void Connect();
 
+        bool GetDoOutput() const;
+
         URL GetURL() const;
 
         int GetContentLength() const;

--- a/Include/AndroidExtensions/JavaWrappers.h
+++ b/Include/AndroidExtensions/JavaWrappers.h
@@ -243,7 +243,7 @@ namespace java::net
 
         void SetDoOutput(bool n);
 
-        void SetRequestProperty(std::string key, std::string value);
+        void SetRequestProperty(const std::string& key, const std::string& value);
 
         URL GetURL() const;
 

--- a/Include/AndroidExtensions/JavaWrappers.h
+++ b/Include/AndroidExtensions/JavaWrappers.h
@@ -23,6 +23,8 @@ namespace java::io
 {
     class ByteArrayOutputStream;
     class InputStream;
+    class OutputStream;
+    class OutputStreamWriter;
 }
 
 namespace java::net
@@ -187,6 +189,22 @@ namespace java::io
 
         int Read(lang::ByteArray byteArray) const;
     };
+
+    class OutputStream : public lang::Object
+    {
+    public:
+        OutputStream(jobject object);
+    };
+
+    class OutputStreamWriter : public lang::Object
+    {
+    public:
+        OutputStreamWriter(jobject object);
+
+        void Write(std::string postBody);
+
+        void Close();
+    };
 }
 
 namespace java::net
@@ -199,6 +217,8 @@ namespace java::net
         HttpURLConnection(jobject object);
 
         int GetResponseCode() const;
+
+        void SetRequestMethod(std::string requestMethod);
     };
 
     class URL : public lang::Object
@@ -234,6 +254,8 @@ namespace java::net
         lang::String GetHeaderFieldKey(int n) const;
 
         io::InputStream GetInputStream() const;
+
+        io::OutputStream GetOutputStream() const;
 
         explicit operator HttpURLConnection() const;
     };

--- a/Source/JavaWrappers.cpp
+++ b/Source/JavaWrappers.cpp
@@ -372,9 +372,23 @@ namespace java::net
 
     bool URLConnection::GetDoOutput() const
     {
-        auto output{m_env->CallObjectMethod(JObject(), m_env->GetMethodID(m_class, "getDoOutput", "()Z;"))};
+        auto output{m_env->CallBooleanMethod(JObject(), m_env->GetMethodID(m_class, "getDoOutput", "()Z"))};
         ThrowIfFaulted(m_env);
-        return {output};
+        return {static_cast<bool>(output)};
+    }
+
+    void URLConnection::SetDoOutput(bool n)
+    {
+        m_env->CallVoidMethod(JObject(),  m_env->GetMethodID(m_class, "setDoOutput", "(Z)V"), true);
+        ThrowIfFaulted(m_env);
+    }
+
+    void URLConnection::SetRequestProperty(std::string key, std::string value)
+    {
+        jstring propertyName = m_env->NewStringUTF(key.c_str());
+        jstring propertyValue = m_env->NewStringUTF(value.c_str());
+        m_env->CallVoidMethod(JObject(), m_env->GetMethodID(m_class, "setRequestProperty", "(Ljava/lang/String;Ljava/lang/String;)V"), propertyName, propertyValue);
+        ThrowIfFaulted(m_env);
     }
 
     void URLConnection::Connect()

--- a/Source/JavaWrappers.cpp
+++ b/Source/JavaWrappers.cpp
@@ -371,7 +371,7 @@ namespace java::net
             throw std::runtime_error("Only POST and GET are supported as arguments to setRequestMethod.");
         }
         jstring requestMethodJstr = m_env->NewStringUTF(requestMethod.c_str());
-        m_env->CallVoidMethod(JObject(),  m_env->GetMethodID(m_class, "setRequestMethod", "(Ljava/lang/String;)V"), requestMethodJstr);
+        m_env->CallVoidMethod(JObject(), m_env->GetMethodID(m_class, "setRequestMethod", "(Ljava/lang/String;)V"), requestMethodJstr);
         ThrowIfFaulted(m_env);
     }
 

--- a/Source/JavaWrappers.cpp
+++ b/Source/JavaWrappers.cpp
@@ -320,7 +320,7 @@ namespace java::io
     }
 
     OutputStream::OutputStream(jobject object)
-            : Object{object}
+        : Object{object}
     {
     }
 

--- a/Source/JavaWrappers.cpp
+++ b/Source/JavaWrappers.cpp
@@ -364,7 +364,7 @@ namespace java::net
         return responseCode;
     }
 
-    void HttpURLConnection::SetRequestMethod(const std::string requestMethod)
+    void HttpURLConnection::SetRequestMethod(const std::string& requestMethod)
     {
         if (requestMethod != "POST" && requestMethod != "GET")
         {
@@ -419,7 +419,7 @@ namespace java::net
         ThrowIfFaulted(m_env);
     }
 
-    void URLConnection::SetRequestProperty(const std::string key, const std::string value)
+    void URLConnection::SetRequestProperty(const std::string& key, const std::string& value)
     {
         jstring propertyName = m_env->NewStringUTF(key.c_str());
         jstring propertyValue = m_env->NewStringUTF(value.c_str());

--- a/Source/JavaWrappers.cpp
+++ b/Source/JavaWrappers.cpp
@@ -456,7 +456,7 @@ namespace java::net
 
     io::OutputStream URLConnection::GetOutputStream() const
     {
-        auto outputStream{m_env->CallObjectMethod(JObject(), m_env->GetMethodID(m_class, "getOutputStream", "()Ljava/io/OutputStream;"))};
+        auto outputStream =m_env->CallObjectMethod(JObject(), m_env->GetMethodID(m_class, "getOutputStream", "()Ljava/io/OutputStream;"));
         ThrowIfFaulted(m_env);
         return {outputStream};
     }

--- a/Source/JavaWrappers.cpp
+++ b/Source/JavaWrappers.cpp
@@ -366,7 +366,7 @@ namespace java::net
 
     void HttpURLConnection::SetRequestMethod(std::string requestMethod)
     {
-        if (requestMethod.compare("POST") != 0 && requestMethod.compare("GET") != 0)
+        if (requestMethod != "POST" && requestMethod != "GET")
         {
             throw std::runtime_error("Only POST and GET are supported as arguments to setRequestMethod.");
         }

--- a/Source/JavaWrappers.cpp
+++ b/Source/JavaWrappers.cpp
@@ -325,7 +325,7 @@ namespace java::io
     }
 
     OutputStreamWriter::OutputStreamWriter(jobject object)
-            : Object{"java/io/OutputStreamWriter"}
+        : Object{"java/io/OutputStreamWriter"}
     {
         JObject(m_env->NewObject(m_class, m_env->GetMethodID(m_class, "<init>", "(Ljava/io/OutputStream;)V"), object));
     }
@@ -364,7 +364,7 @@ namespace java::net
         return responseCode;
     }
 
-    void HttpURLConnection::SetRequestMethod(std::string requestMethod)
+    void HttpURLConnection::SetRequestMethod(const std::string requestMethod)
     {
         if (requestMethod != "POST" && requestMethod != "GET")
         {
@@ -419,7 +419,7 @@ namespace java::net
         ThrowIfFaulted(m_env);
     }
 
-    void URLConnection::SetRequestProperty(std::string key, std::string value)
+    void URLConnection::SetRequestProperty(const std::string key, const std::string value)
     {
         jstring propertyName = m_env->NewStringUTF(key.c_str());
         jstring propertyValue = m_env->NewStringUTF(value.c_str());

--- a/Source/JavaWrappers.cpp
+++ b/Source/JavaWrappers.cpp
@@ -456,7 +456,7 @@ namespace java::net
 
     io::OutputStream URLConnection::GetOutputStream() const
     {
-        auto outputStream =m_env->CallObjectMethod(JObject(), m_env->GetMethodID(m_class, "getOutputStream", "()Ljava/io/OutputStream;"));
+        auto outputStream = m_env->CallObjectMethod(JObject(), m_env->GetMethodID(m_class, "getOutputStream", "()Ljava/io/OutputStream;"));
         ThrowIfFaulted(m_env);
         return {outputStream};
     }

--- a/Source/JavaWrappers.cpp
+++ b/Source/JavaWrappers.cpp
@@ -370,6 +370,13 @@ namespace java::net
     {
     }
 
+    bool URLConnection::GetDoOutput() const
+    {
+        auto output{m_env->CallObjectMethod(JObject(), m_env->GetMethodID(m_class, "getDoOutput", "()Z;"))};
+        ThrowIfFaulted(m_env);
+        return {output};
+    }
+
     void URLConnection::Connect()
     {
         m_env->CallVoidMethod(JObject(), m_env->GetMethodID(m_class, "connect", "()V"));

--- a/Source/JavaWrappers.cpp
+++ b/Source/JavaWrappers.cpp
@@ -408,7 +408,7 @@ namespace java::net
 
     bool URLConnection::GetDoOutput() const
     {
-        auto output{m_env->CallBooleanMethod(JObject(), m_env->GetMethodID(m_class, "getDoOutput", "()Z"))};
+        auto output = m_env->CallBooleanMethod(JObject(), m_env->GetMethodID(m_class, "getDoOutput", "()Z"));
         ThrowIfFaulted(m_env);
         return {static_cast<bool>(output)};
     }


### PR DESCRIPTION
This PR adds support for making POST requests and setting request headers. The added changes include:

 - The `setRequestMethod` (part of the `HttpUrlConnection` class) _to specify the request method (currently only POST and GET supported)_.
 - The `setDoOutput`, `getDoOutput` and `getOutputStream` methods (part of the `UrlConnection` class), and the `OutputStream` and `OutputStreamWriter` classes _to write the body of the POST request_.
 - The `SetRequestProperty` method _to add request headers_.