### PR TITLE
Refactoring initialization and opening of websocket

### DIFF
--- a/Include/AndroidExtensions/JavaWrappers.h
+++ b/Include/AndroidExtensions/JavaWrappers.h
@@ -180,6 +180,7 @@ namespace java::websocket
     public:
         WebSocketClient(std::string url, std::function<void()> open_callback, std::function<void()> close_callback, std::function<void(std::string)> message_callback, std::function<void()> error_callback);
         ~WebSocketClient();
+        void Open();
         void Send(std::string message);
         void Close();
 

--- a/Source/JavaWrappers.cpp
+++ b/Source/JavaWrappers.cpp
@@ -307,10 +307,6 @@ namespace java::websocket
         JObject(m_env->NewObject(m_class, m_env->GetMethodID(m_class, "<init>", "(Ljava/lang/String;)V"), m_env->NewStringUTF(url.c_str())));
 
         s_instances.push_back(std::make_pair(JObject(), this));
-
-        jmethodID connectSocket{m_env->GetMethodID(m_class, "connectBlocking", "()Z")};
-        m_env->CallBooleanMethod(JObject(), connectSocket);
-        ThrowIfFaulted(m_env);
     }
 
     WebSocketClient::~WebSocketClient()
@@ -380,6 +376,13 @@ namespace java::websocket
         {
             return nullptr;
         }
+    }
+
+    void WebSocketClient::Open()
+    {
+        jmethodID connectSocket{m_env->GetMethodID(m_class, "connectBlocking", "()Z")};
+        m_env->CallBooleanMethod(JObject(), connectSocket);
+        ThrowIfFaulted(m_env);
     }
 
     void WebSocketClient::Send(std::string message)


### PR DESCRIPTION
This PR refactors the initialization and opening of the websocket. The opening of the websocket is no longer done in the constructor, but in its own method.