### PR TITLE
Fix a few idempotency and use-after-free issues

### DIFF
--- a/Include/AndroidExtensions/Globals.h
+++ b/Include/AndroidExtensions/Globals.h
@@ -8,9 +8,8 @@
 namespace android::global
 {
     void Initialize(JavaVM* javaVM, jobject appContext);
-    // Passing nullptr for appContext/assetManager clears cached globals so embedders can
-    // explicitly tear down between reloads, or supply only an asset manager when no stable
-    // Java Context is available (e.g., headless/unit-test harnesses).
+    // Overload supporting headless scenarios without a Context.
+    // Safe to call multiple times (e.g., hot reloads).
     void Initialize(JavaVM* javaVM, jobject appContext, jobject assetManager);
 
     JNIEnv* GetEnvForCurrentThread();

--- a/Include/AndroidExtensions/Globals.h
+++ b/Include/AndroidExtensions/Globals.h
@@ -7,7 +7,7 @@
 
 namespace android::global
 {
-    void Initialize(JavaVM* javaVM, jobject appContext);
+    void Initialize(JavaVM* javaVM, jobject context);
     // Passing nullptr for appContext/assetManager clears cached globals so embedders can
     // explicitly tear down between reloads, or supply only an asset manager when no stable
     // Java Context is available (e.g., headless/unit-test harnesses).

--- a/Include/AndroidExtensions/Globals.h
+++ b/Include/AndroidExtensions/Globals.h
@@ -11,7 +11,7 @@ namespace android::global
     // Passing nullptr for appContext/assetManager clears cached globals so embedders can
     // explicitly tear down between reloads, or supply only an asset manager when no stable
     // Java Context is available (e.g., headless/unit-test harnesses).
-    void Initialize(JavaVM* javaVM, jobject appContext, jobject assetManager);
+    void Initialize(JavaVM* javaVM, jobject context, jobject assetManager);
 
     JNIEnv* GetEnvForCurrentThread();
 

--- a/Include/AndroidExtensions/Globals.h
+++ b/Include/AndroidExtensions/Globals.h
@@ -8,7 +8,9 @@
 namespace android::global
 {
     void Initialize(JavaVM* javaVM, jobject appContext);
-    // Passing nullptr for appContext/assetManager clears cached globals during teardown.
+    // Passing nullptr for appContext/assetManager clears cached globals so embedders can
+    // explicitly tear down between reloads, or supply only an asset manager when no stable
+    // Java Context is available (e.g., headless/unit-test harnesses).
     void Initialize(JavaVM* javaVM, jobject appContext, jobject assetManager);
 
     JNIEnv* GetEnvForCurrentThread();

--- a/Include/AndroidExtensions/Globals.h
+++ b/Include/AndroidExtensions/Globals.h
@@ -1,16 +1,21 @@
 #pragma once
 
 #include <jni.h>
+#include <android/asset_manager_jni.h>
 #include <arcana/containers/ticketed_collection.h>
 #include "JavaWrappers.h"
 
 namespace android::global
 {
     void Initialize(JavaVM* javaVM, jobject appContext);
+    void Initialize(JavaVM* javaVM, jobject appContext, jobect assetManager);
 
     JNIEnv* GetEnvForCurrentThread();
 
     android::content::Context GetAppContext();
+
+    void SetAssetManager(jobject assetManager);
+    AAssetManager* GetAssetManager();
 
     android::app::Activity GetCurrentActivity();
     void SetCurrentActivity(jobject currentActivity);

--- a/Include/AndroidExtensions/Globals.h
+++ b/Include/AndroidExtensions/Globals.h
@@ -8,7 +8,7 @@
 namespace android::global
 {
     void Initialize(JavaVM* javaVM, jobject appContext);
-    void Initialize(JavaVM* javaVM, jobject appContext, jobect assetManager);
+    void Initialize(JavaVM* javaVM, jobject appContext, jobject assetManager);
 
     JNIEnv* GetEnvForCurrentThread();
 

--- a/Include/AndroidExtensions/Globals.h
+++ b/Include/AndroidExtensions/Globals.h
@@ -8,6 +8,7 @@
 namespace android::global
 {
     void Initialize(JavaVM* javaVM, jobject appContext);
+    // Passing nullptr for appContext/assetManager clears cached globals during teardown.
     void Initialize(JavaVM* javaVM, jobject appContext, jobject assetManager);
 
     JNIEnv* GetEnvForCurrentThread();

--- a/Include/AndroidExtensions/StdoutLogger.h
+++ b/Include/AndroidExtensions/StdoutLogger.h
@@ -5,4 +5,5 @@ namespace android::StdoutLogger
 {
     void Start();
     void Stop();
+    bool IsStarted();
 }

--- a/Source/Globals.cpp
+++ b/Source/Globals.cpp
@@ -78,14 +78,8 @@ namespace android::global
 
         if (context != nullptr)
         {
-            android::content::Context contextWrapper{context};
-            const auto applicationContextWrapper = contextWrapper.getApplicationContext();
-            jobject applicationContext = applicationContextWrapper;
-
-            if (applicationContext != nullptr)
-            {
-                g_appContext = env->NewGlobalRef(applicationContext);
-            }
+            g_appContext = env->NewGlobalRef(
+                android::content::Context{context}.getApplicationContext());
         }
 
         if (assetManager != nullptr)
@@ -94,9 +88,7 @@ namespace android::global
         }
         else if (context != nullptr)
         {
-            android::content::Context contextWrapper{context};
-            const auto assetsWrapper = contextWrapper.getAssets();
-            SetAssetManager(static_cast<jobject>(assetsWrapper));
+            SetAssetManager(android::content::Context{context}.getAssets());
         }
         else
         {

--- a/Source/StdoutLogger.cpp
+++ b/Source/StdoutLogger.cpp
@@ -4,11 +4,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <mutex>
 
 namespace
 {
-    int fd_stdout[2];
-    int fd_stderr[2];
+    std::mutex g_stateMutex;
+    bool g_started = false;
+    int fd_stdout[2] = {-1, -1};
+    int fd_stderr[2] = {-1, -1};
 
     void thread_func(int fd, int prio)
     {
@@ -65,16 +68,58 @@ namespace android::StdoutLogger
 {
     void Start()
     {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+
+        if (g_started)
+        {
+            return;
+        }
+
         redirect(fd_stdout, fileno(stdout), thread_func_stdout);
         redirect(fd_stderr, fileno(stderr), thread_func_stderr);
+
+        g_started = true;
     }
 
     void Stop()
     {
-        close(fd_stdout[1]);
-        close(fd_stdout[0]);
+        std::lock_guard<std::mutex> lock(g_stateMutex);
 
-        close(fd_stderr[1]);
-        close(fd_stderr[0]);
-   }
+        if (!g_started)
+        {
+            return;
+        }
+
+        g_started = false;
+
+        if (fd_stdout[1] != -1)
+        {
+            close(fd_stdout[1]);
+            fd_stdout[1] = -1;
+        }
+
+        if (fd_stdout[0] != -1)
+        {
+            close(fd_stdout[0]);
+            fd_stdout[0] = -1;
+        }
+
+        if (fd_stderr[1] != -1)
+        {
+            close(fd_stderr[1]);
+            fd_stderr[1] = -1;
+        }
+
+        if (fd_stderr[0] != -1)
+        {
+            close(fd_stderr[0]);
+            fd_stderr[0] = -1;
+        }
+    }
+
+    bool IsStarted()
+    {
+        std::lock_guard<std::mutex> lock(g_stateMutex);
+        return g_started;
+    }
 }


### PR DESCRIPTION
Found when running BabylonNative unit tests in Android simulator using NDK 28c, which automatically enables the `fdsan` sanitizer in clang. This was may have been generally causing instability during process exit on Android.

Will take out of draft when I'm done integration testing in BabylonNative.